### PR TITLE
Remove effects for epidemic trend on fig2

### DIFF
--- a/R/model-plots.R
+++ b/R/model-plots.R
@@ -53,7 +53,7 @@ plot_models <- function(random_effects, scores, x_labels = TRUE) {
 plot_effects <- function(random_effects, scores) {
   random_effects |>
     bind_rows(.id = "outcome_target") |>
-    filter(!(group_var %in% c("Model", "location"))) |>
+    filter(!(group_var %in% c("Model", "location", "Trend"))) |>
     mutate(group = factor(group, levels = unique(as.character(rev(group))))) |>
     ggplot(aes(x = group, col = group_var)) +
     geom_point(aes(y = value)) +


### PR DESCRIPTION
Suggest we remove showing effects for epidemic trend in fig 2, as we don't show effects for any of the other (confounding) variables. We do discuss it in the text though so happy to keep it in and just close this.