### PR TITLE
Fix CI: install gettext for macOS compilation

### DIFF
--- a/.github/workflows/render-report.yaml
+++ b/.github/workflows/render-report.yaml
@@ -31,6 +31,13 @@ jobs:
       - name: Install latex
         uses: r-lib/actions/setup-tinytex@v2
 
+      - name: Install system dependencies
+        run: |
+          brew install gettext libpng
+          mkdir -p ~/.R
+          echo "CPPFLAGS += -I$(brew --prefix gettext)/include -I$(brew --prefix libpng)/include" >> ~/.R/Makevars
+          echo "LDFLAGS += -L$(brew --prefix gettext)/lib -L$(brew --prefix libpng)/lib" >> ~/.R/Makevars
+
       - name: Install dependencies
         uses: r-lib/actions/setup-renv@v2
 

--- a/.github/workflows/test-report.yaml
+++ b/.github/workflows/test-report.yaml
@@ -29,6 +29,13 @@ jobs:
       - name: Install latex
         uses: r-lib/actions/setup-tinytex@v2
 
+      - name: Install system dependencies
+        run: |
+          brew install gettext libpng
+          mkdir -p ~/.R
+          echo "CPPFLAGS += -I$(brew --prefix gettext)/include -I$(brew --prefix libpng)/include" >> ~/.R/Makevars
+          echo "LDFLAGS += -L$(brew --prefix gettext)/lib -L$(brew --prefix libpng)/lib" >> ~/.R/Makevars
+
       - name: Install dependencies
         uses: r-lib/actions/setup-renv@v2
 


### PR DESCRIPTION
## Summary
- Adds `brew install gettext` and configures `~/.R/Makevars` with the correct include/library paths on both CI workflows
- Fixes `libintl.h` not found error when compiling R packages from source (Matrix, data.table) on macOS GitHub Actions runners
- gettext is keg-only on Homebrew, so the paths need to be set explicitly for R's compiler to find them